### PR TITLE
react next added based on eventbrite data

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ A list of [2017 conferences](https://github.com/ryanburgess/2017-conferences).
 
 **When:** April 24-26, 2018
     
+## [React Next](http://react-next.com/)
+**Where:** Tel Aviv, Israel
+
+**When:** September 6, 2018
+    
 ## Contributing
 1. Fork it
 2. Add your conference to `list.json`

--- a/list.json
+++ b/list.json
@@ -375,5 +375,14 @@
     "month": "April",
     "submissionDeadline": "",
     "country": "Slovakia"
+  },
+  {
+    "title": "React Next",
+    "url": "http://react-next.com/",
+    "where": "Tel Aviv, Israel",
+    "when": "September 6, 2018",
+    "month": "September",
+    "submissionDeadline": "",
+    "country": "Israel"
   }
 ]


### PR DESCRIPTION
It's not my event but I participate at the last 2 years and loved it. 
I took the data from the following link as their website is still showing the last year's data. 
https://www.eventbrite.com/e/reactnext-2018-tickets-39688618727  